### PR TITLE
Train word2vec model

### DIFF
--- a/code/word2vec/KaggleWord2VecUtility.py
+++ b/code/word2vec/KaggleWord2VecUtility.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+
+import re
+import nltk
+
+import pandas as pd
+import numpy as np
+
+from bs4 import BeautifulSoup
+from nltk.corpus import stopwords
+
+
+class KaggleWord2VecUtility(object):
+    """KaggleWord2VecUtility is a utility class for processing raw HTML text into segments for further learning"""
+
+    @staticmethod
+    def review_to_wordlist( review, remove_stopwords=False ):
+        # Function to convert a document to a sequence of words,
+        # optionally removing stop words.  Returns a list of words.
+        #
+        # 1. Remove HTML
+        review_text = BeautifulSoup(review).get_text()
+        #
+        # 2. Remove non-letters
+        review_text = re.sub("[^a-zA-Z]"," ", review_text)
+        #
+        # 3. Convert words to lower case and split them
+        words = review_text.lower().split()
+        #
+        # 4. Optionally remove stop words (false by default)
+        if remove_stopwords:
+            stops = set(stopwords.words("english"))
+            words = [w for w in words if not w in stops]
+        #
+        # 5. Return a list of words
+        return(words)
+
+    # Define a function to split a review into parsed sentences
+    @staticmethod
+    def review_to_sentences( review, tokenizer, remove_stopwords=False ):
+        # Function to split a review into parsed sentences. Returns a
+        # list of sentences, where each sentence is a list of words
+        #
+        # 1. Use the NLTK tokenizer to split the paragraph into sentences
+        raw_sentences = tokenizer.tokenize(review.encode('unicode-escape').decode('ascii').strip())
+        #
+        # 2. Loop over each sentence
+        sentences = []
+        for raw_sentence in raw_sentences:
+            # If a sentence is empty, skip it
+            if len(raw_sentence) > 0:
+                # Otherwise, call review_to_wordlist to get a list of words
+                sentences.append( KaggleWord2VecUtility.review_to_wordlist( raw_sentence, \
+                  remove_stopwords ))
+        #
+        # Return the list of sentences (each sentence is a list of words,
+        # so this returns a list of lists
+        return sentences

--- a/code/word2vec/Word2VecTrainer.py
+++ b/code/word2vec/Word2VecTrainer.py
@@ -1,0 +1,72 @@
+# Before running this, remember to download the punkt data:
+# nltk.download('punkt')
+
+from gensim.models import Word2Vec
+from KaggleWord2VecUtility import KaggleWord2VecUtility
+import logging
+import nltk.data
+import pandas as pd
+
+# Set values for various parameters. We may wanna tune these
+NUM_FEATURES = 300    # Word vector dimensionality
+MIN_WORD_COUNT = 40   # Minimum word count
+NUM_WORKERS = 4       # Number of threads to run in parallel
+CONTEXT = 10          # Context window size
+DOWNSAMPLING = 1e-3   # Downsample setting for frequent words
+
+MODEL_NAME = "300features_40minwords_10context"
+
+if __name__ == '__main__':
+
+    # Read data from files
+    dataset_A = pd.read_csv( "../../dataset/processed/A.tsv", header=0, delimiter="\t", quoting=3 )
+    dataset_D = pd.read_csv( "../../dataset/processed/D.tsv", header=0, delimiter="\t", quoting=3 )
+    dataset_E = pd.read_csv( "../../dataset/processed/E.tsv", header=0, delimiter="\t", quoting=3 )
+
+    # Verify the number of reviews that were read (95,000 in total)
+    print ("Read %d labeled A reviews, %d unlabeled D reviews, " \
+     "and %d unlabeled E reviews\n" % (dataset_A["review"].size,
+     dataset_D["review"].size, dataset_E["review"].size ))
+
+
+
+    # Load the punkt tokenizer
+    tokenizer = nltk.data.load('tokenizers/punkt/english.pickle')
+
+
+
+    # ****** Split the training sets into clean sentences
+    #
+    sentences = []  # Initialize an empty list of sentences
+
+    print ("Parsing sentences from dataset A")
+    for review in dataset_A["review"]:
+        sentences += KaggleWord2VecUtility.review_to_sentences(review, tokenizer)
+
+    print ("Parsing sentences from dataset D")
+    for review in dataset_D["review"]:
+        sentences += KaggleWord2VecUtility.review_to_sentences(review, tokenizer)
+
+    print ("Parsing sentences from dataset E")
+    for review in dataset_E["review"]:
+        sentences += KaggleWord2VecUtility.review_to_sentences(review, tokenizer)
+
+    # ****** Set parameters and train the word2vec model
+    #
+    # Import the built-in logging module and configure it so that Word2Vec
+    # creates nice output messages
+    logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s',\
+        level=logging.INFO)
+
+    # Initialize and train the model (this will take some time)
+    print ("Training Word2Vec model...")
+    model = Word2Vec(sentences, workers=NUM_WORKERS, \
+                size=NUM_FEATURES, min_count = MIN_WORD_COUNT, \
+                window = CONTEXT, sample = DOWNSAMPLING, seed=1)
+
+    # If you don't plan to train the model any further, calling
+    # init_sims will make the model much more memory-efficient.
+    model.init_sims(replace=True)
+
+    # You can load the model later using Word2Vec.load()
+    model.save(MODEL_NAME)


### PR DESCRIPTION
### Summary

- Port `KaggleWord2VecUtility` from python 2 to 3 (1 line change)
- Create `Word2VecTrainer` using the same example params from the Word2Vec tutorial code, but on datasets A + D + E
- Commit the saved word2vec model

### Testing
```
>>> model.doesnt_match("man woman child kitchen".split())
<stdin>:1: DeprecationWarning: Call to deprecated `doesnt_match` (Method will be removed in 4.0.0, use self.wv.doesnt_match() instead).
/Users/surajb/anaconda3/envs/project/lib/python3.9/site-packages/gensim/models/keyedvectors.py:877: FutureWarning: arrays to stack must be passed as a "sequence" type such as list or tuple. Support for non-sequence iterables such as generators is deprecated as of NumPy 1.16 and will raise an error in the future.
  vectors = vstack(self.word_vec(word, use_norm=True) for word in used_words).astype(REAL)
'kitchen'
>>> model.doesnt_match("france england germany berlin".split())
'berlin'
>>> model.doesnt_match("paris berlin london austria".split())
'austria'
>>> model.most_similar("man")
<stdin>:1: DeprecationWarning: Call to deprecated `most_similar` (Method will be removed in 4.0.0, use self.wv.most_similar() instead).
[('lad', 0.636806845664978), ('woman', 0.6060831546783447), ('lady', 0.5934877395629883), ('monk', 0.5336718559265137), ('guy', 0.5324569940567017), ('men', 0.5266843438148499), ('farmer', 0.5263856649398804), ('soldier', 0.5252387523651123), ('businessman', 0.5211970806121826), ('widower', 0.5136975049972534)]
>>> model.most_similar("queen")
[('princess', 0.6416501998901367), ('goddess', 0.5968104600906372), ('belle', 0.5643520951271057), ('stripper', 0.5594625473022461), ('bride', 0.5587148666381836), ('latifah', 0.5563135743141174), ('countess', 0.5548009276390076), ('victoria', 0.5546269416809082), ('maid', 0.5526178479194641), ('dame', 0.5520363450050354)]
>>> model.most_similar("awful")
[('terrible', 0.7608219385147095), ('atrocious', 0.728529155254364), ('horrible', 0.7178652882575989), ('dreadful', 0.7164702415466309), ('abysmal', 0.7151340246200562), ('horrid', 0.6676855087280273), ('horrendous', 0.6608156561851501), ('appalling', 0.6597209572792053), ('lousy', 0.6573832631111145), ('crappy', 0.6082762479782104)]
```
