### PR TITLE
Automate convergence, save model state, and fix bug in loss/accuracy …

### DIFF
--- a/code/NN_Implementation/framework_lstm_attempt_1.py
+++ b/code/NN_Implementation/framework_lstm_attempt_1.py
@@ -1,8 +1,8 @@
 import collections
+import json
 from KaggleWord2VecUtility import KaggleWord2VecUtility
 from nn_lstm_attempt_1 import LSTM
 import nn_tools
-import pyhelpers
 import torch
 import torchtext
 from tqdm import tqdm
@@ -23,6 +23,7 @@ WORD2VEC_WORD_FREQ_FILE_PATH = "../../word2vecModels/300features_40minwords_10co
 
 def trainOneEpoch(lstm, iterator, optimizer, loss_function):
     total_loss = 0
+    total_count = 0
     lstm.train()
     for batch in tqdm(iterator):
         text, text_lengths = batch.review
@@ -40,13 +41,17 @@ def trainOneEpoch(lstm, iterator, optimizer, loss_function):
         # Do a weight update step
         optimizer.step()
 
-        total_loss += loss.item()
+        batch_size = text.size()[0]
+        total_loss += loss.item() * batch_size
+        total_count += batch_size
 
-    print ("Average loss:", total_loss / len(iterator))
+    print ("Average train set loss:", total_loss / total_count)
 
 
-def evaluate(lstm, iterator, classification_threshold=0.5):
+def evaluate(lstm, iterator, loss_function, classification_threshold=0.5):
     total_accuracy = 0
+    total_loss = 0
+    total_count = 0
     lstm.eval()
     with torch.no_grad():
         for batch in tqdm(iterator):
@@ -54,17 +59,26 @@ def evaluate(lstm, iterator, classification_threshold=0.5):
 
             predictions = lstm(text, text_lengths).squeeze()
 
+            loss = loss_function(predictions, batch.sentiment)
+
             # TODO use classification threshold
             rounded_predictions = torch.round(predictions)
 
             accuracy = nn_tools.AccuracyFromTensors(batch.sentiment, rounded_predictions)
 
-            total_accuracy += accuracy.item()
+            batch_size = text.size()[0]
+            total_accuracy += accuracy.item() * batch_size
+            total_loss += loss.item() * batch_size
+            total_count += batch_size
 
-    return total_accuracy / len(iterator)
+    print ("Average loss:", total_loss / total_count)
+    
+    return total_accuracy / total_count
 
 
 if __name__ == '__main__':
+    model_file_path = input("Model file path? ")
+
     # preprocess data
     text = torchtext.data.Field(tokenize=KaggleWord2VecUtility.review_to_wordlist, batch_first=True, include_lengths=True)
     label = torchtext.data.LabelField(dtype=torch.float, batch_first=True)
@@ -87,7 +101,8 @@ if __name__ == '__main__':
         
         vectors = torchtext.vocab.Vectors(WORD2VEC_VECTORS_FILE_PATH)
 
-        word_counter = collections.Counter(pyhelpers.store.load_json(WORD2VEC_WORD_FREQ_FILE_PATH, verbose=True))
+        with open(WORD2VEC_WORD_FREQ_FILE_PATH) as word_freq_file:
+            word_counter = collections.Counter(json.load(word_freq_file))
 
         vocab = torchtext.vocab.Vocab(word_counter, vectors=vectors)
 
@@ -121,14 +136,28 @@ if __name__ == '__main__':
     loss_function = torch.nn.BCELoss()
 
     epoch = 0
+    best_dev_set_accuracy = 0
+    dev_set_accuracy = evaluate(lstm, dev_iterator, loss_function)
     print ("Epoch:", epoch)
-    print ("Dev set accuracy:", evaluate(lstm, dev_iterator))
-    # TODO automate convergence
-    user_input = str(input("Continue training? y/n: "))
-    while user_input.lower() == "y":
+    print ("Dev set accuracy:", dev_set_accuracy)
+    while epoch < 5 or dev_set_accuracy >= best_dev_set_accuracy:
+        # save the best model
+        if dev_set_accuracy >= best_dev_set_accuracy:
+            best_dev_set_accuracy = dev_set_accuracy
+            torch.save(lstm.state_dict(), model_file_path)
+
         trainOneEpoch(lstm, train_iterator, optimizer, loss_function)
         epoch += 1
-
+        dev_set_accuracy = evaluate(lstm, dev_iterator, loss_function)
         print ("Epoch:", epoch)
-        print ("Dev set accuracy:", evaluate(lstm, dev_iterator))
-        user_input = str(input("Continue training? y/n"))
+        print ("Dev set accuracy:", dev_set_accuracy)
+
+
+    print("EVALUATION")
+
+    # reload the best model
+    lstm = LSTM(NUM_FEATURES, HIDDEN_SIZE, NUM_LAYERS, DROPOUT, BIDIRECTIONAL, len(text.vocab))
+    lstm.load_state_dict(torch.load(model_file_path))
+
+    print ("Final train set accuracy:", evaluate(lstm, train_iterator, loss_function))
+    print ("Final dev set accuracy:", evaluate(lstm, dev_iterator, loss_function))


### PR DESCRIPTION
…calculations

- Automate the convergence logic to train at least 5 epochs, or continue training as long as the dev set accuracy improves
- Save the best model state so that it can be loaded for evaluation at the end (this should also help with using the final tuned model to evaluate on the test set)
- Calculating the loss/accuracy was giving each batch an equal weight without looking at the batch size, which is now fixed
